### PR TITLE
Make test directory into a module. Fix mock object imports

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -30,6 +30,6 @@ jobs:
     - name: Run tests
       run: |
         cd worker/source/
-        python3.11 -m pytest -vv --durations=0 -s -m unit
-        python3.11 -m pytest -vv --durations=0 -s -m integration
-        python3.11 -m pytest -vv --durations=0 -s -m system
+        pytest -vv --durations=0 -s -m unit
+        pytest -vv --durations=0 -s -m integration
+        pytest -vv --durations=0 -s -m system

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The following is a guide to get DCS up and running. It also describes how to tes
 | 5.&nbsp;(Optional)&nbsp;Install&nbsp;Python   | Version 3.11 or greater. This step is required to run the Python-based worker or its tests outside of a container. Ref: https://www.python.org/downloads/                                                                                               |
 
 # Test It!
-In addition to the informal manual testing that takes place in development, some tests were automated and they are part of this repo.
+In addition to the informal manual testing that takes place in development, some tests were automated and they are part of this repo. The following commands can be executed via shell from the directory where dcs was cloned (i.e. named "dcs" by default).
 
 ## Lightweight test strategy
 Tests are categorized according to their type - as system, integration, or unit. The test functions are annotated using markers of the same name ([an example](https://github.com/bunchofstring/dcs/blob/c6a24bd06a41855a336edbd6e96b99c2296bf35c/worker/source/test_sandbox.py#L30)). For marker definitions, see [pytest.ini](pytest.ini). Below is a command to quickly count tests of each type.
@@ -45,9 +45,9 @@ Notice that the proportion of different test types does not match the classic "t
 ## Expected behavior
 Staged testing helps facilitate fast feedback on new code changes. The commands below will find and execute tests with the associated marker.
 ```shell
-python3.11 -m pytest -vv --durations=0 -m unit && \
-python3.11 -m pytest -vv --durations=0 -m integration && \
-python3.11 -m pytest -vv --durations=0 -m system
+pytest -vv --durations=0 -m unit && \
+pytest -vv --durations=0 -m integration && \
+pytest -vv --durations=0 -m system
 ```
 Note: The test categories above are intentionally ordered from fastest to slowest. There are other ways to index the tests (e.g. smoke, sanity, etc.) but the organizational scheme was chosen to highlight the nature of each test.
 ## Acceptable performance
@@ -120,6 +120,14 @@ Percentage of the requests served within a certain time (ms)
 </details>
 
 # Lessons Learned
+
+## Pytest
+Some useful things about Pytest
+1. Verbose output for test execution
+   In the command to execute tests, enter the following immediately after `pytest`
+   ```shell
+   -vv --durations=0 -s
+   ```
 
 ## Docker and Docker Compose
 A small collection of useful docker commands.

--- a/README.md
+++ b/README.md
@@ -130,8 +130,7 @@ Percentage of the requests served within a certain time (ms)
 
 ## Pytest
 Some useful things about Pytest
-1. Verbose output for test execution
-   In the command to execute tests, enter the following immediately after `pytest`
+1. Verbose output for test execution. In the command to execute tests, enter the following immediately after `pytest`
    ```shell
    -vv --durations=0 -s
    ```

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The automated tests are categorized according to their type - as system, integra
 
 This taxonomy highlights the nature of each test. Even this basic structure can reinforce good practices and provide a basis for measurement. Note that there are other ways to categorize the tests (e.g. smoke, sanity, performance etc.) but the main point is to start measuring! This can improve any practice and help tackle difficult questions as a product matures. Which tests are the most valuable? Wich ones are the most expensive to write and execute?
 
-Below is a command to quickly count tests of each type. In the output, the first number on each line indicates the number of tests of that type. 
+Below is a command to quickly count tests of each type. In the output, the first number on each line indicates the number of tests of that type. Note that the classic "test pyramid" shape is a good guideline, but it is not a strict requirement (ref: https://martinfowler.com/articles/2021-test-shapes.html).
 ```shell
 pytest -m system --collect-only | grep "tests collected" && \
 pytest -m integration --collect-only | grep "tests collected" && \
@@ -38,14 +38,14 @@ pytest -m unit --collect-only | grep "tests collected"
 ```
 <details>
   <summary>Sample output from the above command</summary>
-Sample output below shows system (4), integration (2), and unit (3) tests.
+<br>
+System (4), integration (2), and unit (3) tests.
+
 ```shell
 ================= 4/9 tests collected (5 deselected) in 0.03s ==================
 ================= 2/9 tests collected (7 deselected) in 0.03s ==================
 ================= 3/9 tests collected (6 deselected) in 0.03s ==================
 ```
-
-Notice that the proportion of different test types does not match the classic "test pyramid" shape. However, this is only a guideline (ref: https://martinfowler.com/articles/2021-test-shapes.html).
 </details>
 
 ## Expected behavior

--- a/README.md
+++ b/README.md
@@ -24,16 +24,21 @@ The following is a guide to get DCS up and running. It also describes how to tes
 | 5.&nbsp;(Optional)&nbsp;Install&nbsp;Python   | Version 3.11 or greater. This step is required to run the Python-based worker or its tests outside of a container. Ref: https://www.python.org/downloads/                                                                                               |
 
 # Test It!
-In addition to the informal manual testing that takes place in development, some tests were automated and they are part of this repo. The following commands can be executed via shell from the directory where dcs was cloned (i.e. named "dcs" by default).
+In addition to the informal manual testing that takes place during development, some tests were automated and they are part of this repo. The commands in this section can be executed via shell from the directory where this repo was cloned (i.e. named "dcs" by default).
 
-## Lightweight test strategy
-Tests are categorized according to their type - as system, integration, or unit. The test functions are annotated using markers of the same name ([an example](https://github.com/bunchofstring/dcs/blob/c6a24bd06a41855a336edbd6e96b99c2296bf35c/worker/source/test_sandbox.py#L30)). For marker definitions, see [pytest.ini](pytest.ini). Below is a command to quickly count tests of each type.
+The automated tests are categorized according to their type - as system, integration, or unit. The functions themselves are annotated using markers of the same name ([an example](https://github.com/bunchofstring/dcs/blob/c6a24bd06a41855a336edbd6e96b99c2296bf35c/worker/source/test_sandbox.py#L30)). For marker definitions, see [pytest.ini](pytest.ini).
+
+This taxonomy highlights the nature of each test. Even this basic structure can reinforce good practices and provide a basis for measurement. Note that there are other ways to categorize the tests (e.g. smoke, sanity, performance etc.) but the main point is to start measuring! This can improve any practice and it can help tackle difficult questions as the product matures. Which tests are the most valuable? Wich ones are the most expensive to write and execute?
+
+Below is a command to quickly count tests of each type. In the output, the first number on each line indicates the number of tests of that type. 
 ```shell
 pytest -m system --collect-only | grep "tests collected" && \
 pytest -m integration --collect-only | grep "tests collected" && \
 pytest -m unit --collect-only | grep "tests collected"
 ```
-The first number on each line indicates the number of tests of that type. Sample output below shows system, integration, and unit - in that order.
+<details>
+  <summary>Sample output from the above command</summary>
+Sample output below shows system (4), integration (2), and unit (3) tests.
 ```shell
 ================= 4/9 tests collected (5 deselected) in 0.03s ==================
 ================= 2/9 tests collected (7 deselected) in 0.03s ==================
@@ -41,15 +46,17 @@ The first number on each line indicates the number of tests of that type. Sample
 ```
 
 Notice that the proportion of different test types does not match the classic "test pyramid" shape. However, this is only a guideline (ref: https://martinfowler.com/articles/2021-test-shapes.html).
+</details>
 
 ## Expected behavior
 Staged testing helps facilitate fast feedback on new code changes. The commands below will find and execute tests with the associated marker.
 ```shell
-pytest -vv --durations=0 -m unit && \
-pytest -vv --durations=0 -m integration && \
-pytest -vv --durations=0 -m system
+pytest -m unit && \
+pytest -m integration && \
+pytest -m system
 ```
-Note: The test categories above are intentionally ordered from fastest to slowest. There are other ways to index the tests (e.g. smoke, sanity, etc.) but the organizational scheme was chosen to highlight the nature of each test.
+Note: The test categories above are intentionally ordered. The idea is to run many fast tests up front and identify problems as directly as possible.
+
 ## Acceptable performance
 Apache Bench can generate significant load on the system and provides human-readable results. Thanks to a kind Internet stranger named Jordi (https://github.com/jig/docker-ab), it is conveniently packaged and available on Docker Hub. Give it a try! Execute the command below to perform 10,000 requests within 30 seconds.
 ```shell

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ In addition to the informal manual testing that takes place during development, 
 
 The automated tests are categorized according to their type - as system, integration, or unit. The functions themselves are annotated using markers of the same name ([an example](https://github.com/bunchofstring/dcs/blob/c6a24bd06a41855a336edbd6e96b99c2296bf35c/worker/source/test_sandbox.py#L30)). For marker definitions, see [pytest.ini](pytest.ini).
 
-This taxonomy highlights the nature of each test. Even this basic structure can reinforce good practices and provide a basis for measurement. Note that there are other ways to categorize the tests (e.g. smoke, sanity, performance etc.) but the main point is to start measuring! This can improve any practice and it can help tackle difficult questions as the product matures. Which tests are the most valuable? Wich ones are the most expensive to write and execute?
+This taxonomy highlights the nature of each test. Even this basic structure can reinforce good practices and provide a basis for measurement. Note that there are other ways to categorize the tests (e.g. smoke, sanity, performance etc.) but the main point is to start measuring! This can improve any practice and help tackle difficult questions as a product matures. Which tests are the most valuable? Wich ones are the most expensive to write and execute?
 
 Below is a command to quickly count tests of each type. In the output, the first number on each line indicates the number of tests of that type. 
 ```shell

--- a/worker/source/test/test_service.py
+++ b/worker/source/test/test_service.py
@@ -2,11 +2,11 @@
 import ipaddress
 import platform
 import socket
-import mock_socket_package
-import mock_socket_object
 
 import pytest
 
+from . import mock_socket_object
+from . import mock_socket_package
 import worker.service as service
 
 unsupported_platform = {


### PR DESCRIPTION
Outcome: Can execute tests via pytest (directly) OR via python -m pytest. Same results